### PR TITLE
chore: deployment to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # to access the repository
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
@@ -41,3 +47,17 @@ jobs:
 
       - name: Typecheck
         run: pnpm run typecheck
+
+      - name: Build
+        run: pnpm run generate
+
+      - name: Upload artifacts
+        # https://github.com/actions/upload-pages-artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./.output/public"
+
+      - name: Deploy GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        # https://github.com/actions/deploy-pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request sets up a GitHub Actions workflow for deploying the project to GitHub Pages.

Don't forget to adjust the GitHub settings.


<img width="708" alt="image" src="https://github.com/user-attachments/assets/57c08bd5-cbfa-4ac6-bca4-61399e12ebf4">

